### PR TITLE
make config updates feasible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   config-server:
-    image: mszarlinski/spring-petclinic-config-server
+    image: bryannoland/spring-petclinic-config-server
     container_name: config-server
     ports:
      - 8888:8888
@@ -9,7 +9,7 @@ services:
 
 
   discovery-server:
-    image: mszarlinski/spring-petclinic-discovery-server
+    image: bryannoland/spring-petclinic-discovery-server
     container_name: discovery-server
     links:
      - config-server
@@ -20,12 +20,12 @@ services:
      - 8761:8761
 
   customers-service:
-    image: mszarlinski/spring-petclinic-customers-service
+    image: bryannoland/spring-petclinic-customers-service
     container_name: customers-service
     links:
      - config-server
      - discovery-server
-     - tracing-server
+#     - tracing-server
     depends_on:
      - config-server
      - discovery-server
@@ -34,12 +34,12 @@ services:
     - 8081:8081
 
   visits-service:
-    image: mszarlinski/spring-petclinic-visits-service
+    image: bryannoland/spring-petclinic-visits-service
     container_name: visits-service
     links:
      - config-server
      - discovery-server
-     - tracing-server
+#     - tracing-server
     depends_on:
      - config-server
      - discovery-server
@@ -48,12 +48,12 @@ services:
      - 8082:8082
 
   vets-service:
-    image: mszarlinski/spring-petclinic-vets-service
+    image: bryannoland/spring-petclinic-vets-service
     container_name: vets-service
     links:
      - config-server
      - discovery-server
-     - tracing-server
+#     - tracing-server
     depends_on:
      - config-server
      - discovery-server
@@ -62,7 +62,7 @@ services:
      - 8083:8083
 
   api-gateway:
-    image: mszarlinski/spring-petclinic-api-gateway
+    image: bryannoland/spring-petclinic-api-gateway
     container_name: api-gateway
     links:
      - config-server
@@ -70,7 +70,7 @@ services:
      - customers-service
      - visits-service
      - vets-service
-     - tracing-server
+#     - tracing-server
     depends_on:
      - config-server
      - discovery-server
@@ -78,28 +78,28 @@ services:
     ports:
      - 8080:8080
 
-  tracing-server:
-    image: mszarlinski/spring-petclinic-tracing-server
-    container_name: tracing-server
-    links:
-     - config-server
-     - discovery-server
-    depends_on:
-     - config-server
-     - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
-    ports:
-     - 9411:9411
+#  tracing-server:
+#    image: bryannoland/spring-petclinic-tracing-server
+#    container_name: tracing-server
+#    links:
+#     - config-server
+#     - discovery-server
+#    depends_on:
+#     - config-server
+#     - discovery-server
+#    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+#    ports:
+#     - 9411:9411
 
-  admin-server:
-    image: mszarlinski/spring-petclinic-admin-server
-    container_name: admin-server
-    links:
-     - config-server
-     - discovery-server
-    depends_on:
-     - config-server
-     - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
-    ports:
-     - 9090:9090
+#  admin-server:
+#    image: bryannoland/spring-petclinic-admin-server
+#    container_name: admin-server
+#    links:
+#     - config-server
+#     - discovery-server
+#    depends_on:
+#     - config-server
+#     - discovery-server
+#    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+#    ports:
+#     - 9090:9090

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<packaging>pom</packaging>
 
 	<modules>
-		<module>spring-petclinic-admin-server</module>
+<!--		<module>spring-petclinic-admin-server</module>-->
 		<module>spring-petclinic-customers-service</module>
 		<module>spring-petclinic-vets-service</module>
 		<module>spring-petclinic-visits-service</module>
@@ -23,7 +23,7 @@
         <module>spring-petclinic-discovery-server</module>
         <module>spring-petclinic-api-gateway</module>
         <module>spring-petclinic-monitoring</module>
-        <module>spring-petclinic-tracing-server</module>
+<!--        <module>spring-petclinic-tracing-server</module>-->
     </modules>
 
     <properties>
@@ -35,7 +35,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-		<docker.image.prefix>mszarlinski</docker.image.prefix>
+		<docker.image.prefix>bryannoland</docker.image.prefix>
         <docker.image.exposed.port>9090</docker.image.exposed.port>
         <docker.image.dockerfile.dir>${basedir}</docker.image.dockerfile.dir>
 		<docker.plugin.version>0.4.13</docker.plugin.version>

--- a/spring-petclinic-admin-server/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-admin-server/src/main/resources/bootstrap.yml
@@ -2,7 +2,7 @@ spring:
   cloud:
     config:
       uri: http://localhost:8888
-      label: 1e9c6759a423e3984c6d73d002c0fd2ebf5abeb5
+            label: poc
   application:
     name: admin-server
 ---
@@ -11,8 +11,5 @@ spring:
   cloud:
     config:
       uri: http://config-server:8888
-eureka:
-  instance:
-    # enable to register multiple app instances with a random server port
-    instance-id: ${spring.application.name}:${random.uuid}
+
 

--- a/spring-petclinic-api-gateway/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-api-gateway/src/main/resources/bootstrap.yml
@@ -2,7 +2,7 @@ spring:
   cloud:
     config:
       uri: http://localhost:8888
-      label: 1e9c6759a423e3984c6d73d002c0fd2ebf5abeb5
+      label: poc
   application:
     name: api-gateway
 ---

--- a/spring-petclinic-config-server/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-config-server/src/main/resources/bootstrap.yml
@@ -4,10 +4,9 @@ spring:
     config:
       server:
         git:
-          uri: https://github.com/spring-petclinic/spring-petclinic-microservices-config
-#          skipSslValidation: true
+          uri: https://github.com/wheelspinner/spring-petclinic-microservices-config
           cloneOnStart: true
-          default-label: master
+          default-label: poc
       enabled: false
 logging:
   level:

--- a/spring-petclinic-customers-service/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-customers-service/src/main/resources/bootstrap.yml
@@ -2,7 +2,7 @@ spring:
   cloud:
     config:
       uri: http://localhost:8888
-      label: 1e9c6759a423e3984c6d73d002c0fd2ebf5abeb5
+      label: poc
   application:
     name: customers-service
 ---

--- a/spring-petclinic-discovery-server/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-discovery-server/src/main/resources/bootstrap.yml
@@ -2,6 +2,7 @@ spring:
   cloud:
     config:
       uri: http://localhost:8888
+      label: poc
   application:
     name: discovery-server
 ---
@@ -10,35 +11,3 @@ spring:
   cloud:
     config:
       uri: http://config-server:8888
-      label: 15290addbd85bc75d677bcde409919c045fccfb6
-server:
-  port: 8761
-eureka:
-  instance:
-    hostname: localhost
-    non-secure-port: ${PORT:8761}
-  server:
-    enable-self-preservation: false
-    peer-node-read-timeout-ms: 6000
-  client:
-    register-with-eureka: false
-    fetch-registry: false
-    healthcheck:
-      enabled: true
-    service-url:
-      defaultZone: http://${eureka.instance.hostname}:${server.port}/eureka/
-
-  devtools:
-    livereload:
-      enabled: false
-
-endpoints:
-  sensitive: false
-
-security:
-  basic:
-    enabled: false
-
-management:
-  security:
-    enabled: false

--- a/spring-petclinic-tracing-server/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-tracing-server/src/main/resources/bootstrap.yml
@@ -2,7 +2,7 @@ spring:
   cloud:
     config:
       uri: http://localhost:8888
-      label: 1e9c6759a423e3984c6d73d002c0fd2ebf5abeb5
+            label: poc
   application:
     name: tracing-server
 ---

--- a/spring-petclinic-vets-service/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-vets-service/src/main/resources/bootstrap.yml
@@ -2,7 +2,7 @@ spring:
   cloud:
     config:
       uri: http://localhost:8888
-      label: 1e9c6759a423e3984c6d73d002c0fd2ebf5abeb5
+      label: poc
   application:
     name: vets-service
 ---

--- a/spring-petclinic-visits-service/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-visits-service/src/main/resources/bootstrap.yml
@@ -2,7 +2,7 @@ spring:
   cloud:
     config:
       uri: http://localhost:8888
-      label: 1e9c6759a423e3984c6d73d002c0fd2ebf5abeb5
+      label: poc
   application:
     name: visits-service
 ---


### PR DESCRIPTION
points to a config rep we control.

removes uneeded config

don't build admin-server and tracing-server as they aren't needed for poc

updates docker image names